### PR TITLE
PR for fixing the improper authentication bug.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,7 @@ module.exports = function (sequelize, secret) {
         jwt.verify(token, secret, function(err, data) {
           if (err)
           {
-            response.status(401).json({ error: "Invalid Token" });
-            throw new Error("Invalid Token");
+            response.status(401).json({ error: err });
           }
         });
         const { jti } = jwt.decode(token);

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ module.exports = function (sequelize, secret) {
         jwt.verify(token, secret, function(err, data) {
           if (err)
           {
-            response.status(401).json({ error: err });
+            next(err)
           }
         });
         const { jti } = jwt.decode(token);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 const jwt = require('jsonwebtoken');
 
-module.exports = function (sequelize) {
+/*
+ * Adding 'secret' parameter during setup/initialization of `passport` instance.
+ * All future token sent to this server, will be verified using this key.
+ */
+module.exports = function (sequelize, secret) {
   const OauthAccessToken = require('./OauthAccessToken')(sequelize);
   
   return async function passport_middleware(request, response, next) {
@@ -10,8 +14,18 @@ module.exports = function (sequelize) {
       const comp = authorization.split(' ');
       if (comp.length == 2 && comp[0] == 'Bearer') {
         const token = comp[1];
+        /* Before we can assign the user id, we need to make sure the token
+         * is properly signed. This will mitigate the improper authentication
+         * attempts.
+         */
+        jwt.verify(token, secret, function(err, data) {
+          if (err)
+          {
+            response.status(401).json({ error: "Invalid Token" });
+            throw new Error("Invalid Token");
+          }
+        });
         const { jti } = jwt.decode(token);
-
         const access_token = await OauthAccessToken.findById(jti);
         request.user_id = access_token.user_id
       }


### PR DESCRIPTION
The root cause for this bug is not verifying the signature on the JWT token. Actually, not even including a secret during initialization of `passport` in the server, seems to be the real root cause, since then the server is just accepting JWT token without verification.

Fixes include:

- Adding secret in initialization of `passport` object.
- Calling `jwt.verify()` before `jwt.decode()`, returning a response of 401: Invalid Token if the token is invalid.